### PR TITLE
Scan AWS Backup plans for cross-account copy

### DIFF
--- a/source/lambda/aws/services/backup.py
+++ b/source/lambda/aws/services/backup.py
@@ -50,3 +50,20 @@ class Backup:
         self.logger.debug(f"Backup Vault Access Policy: {response}")
         return response
 
+    @service_exception_handler
+    def list_backup_plans(self):
+        response = self.backup_client.list_backup_plans()
+        plans = response.get('BackupPlansList', [])
+        next_token = response.get('NextToken', None)
+
+        while next_token is not None:
+            response = self.backup_client.list_backup_plans(NextToken=next_token)
+            plans.extend(response.get('BackupPlansList', []))
+            next_token = response.get('NextToken', None)
+
+        return plans
+
+    @service_exception_handler
+    def get_backup_plan(self, backup_plan_id: str):
+        return self.backup_client.get_backup_plan(BackupPlanId=backup_plan_id)
+

--- a/source/lambda/policy_explorer/step_functions_lambda/scan_backup_vault_access_policy.py
+++ b/source/lambda/policy_explorer/step_functions_lambda/scan_backup_vault_access_policy.py
@@ -47,8 +47,7 @@ class BackupVaultAccessPolicy:
         }
         return data
 
-    @staticmethod
-    def _get_backup_policies(backup_data: list[model.BackupData],
+    def _get_backup_policies(self, backup_data: list[model.BackupData],
                              backup_client) -> list[model.PolicyDetails]:
         backup_policies = []
         for vault in backup_data:
@@ -60,4 +59,40 @@ class BackupVaultAccessPolicy:
             policy_details.update({'Policy': policy.get('Policy')})
             policy_details.update({'PolicyType': model.PolicyType.RESOURCE_BASED_POLICY})
             backup_policies.append(policy_details)
+
+        backup_policies.extend(self._check_backup_plans_with_cross_account_copy(backup_client))
         return backup_policies
+
+    def _check_backup_plans_with_cross_account_copy(self, backup_client) -> list[model.PolicyDetails]:
+        policies = []
+        try:
+            plans = backup_client.list_backup_plans()
+            for plan_summary in plans:
+                plan_id = plan_summary.get('BackupPlanId')
+                plan_arn = plan_summary.get('BackupPlanArn')
+
+                plan_details = backup_client.get_backup_plan(plan_id)
+                backup_plan = plan_details.get('BackupPlan', {})
+
+                for rule in backup_plan.get('Rules', []):
+                    copy_actions = rule.get('CopyActions', [])
+                    for copy_action in copy_actions:
+                        dest_vault_arn = copy_action.get('DestinationBackupVaultArn', '')
+                        if dest_vault_arn and ':' in dest_vault_arn:
+                            dest_account = dest_vault_arn.split(':')[4]
+                            if dest_account != self.account_id:
+                                policy_details: model.PolicyDetails = get_policy_details_from_arn(plan_arn)
+                                policy_statement = {
+                                    "Effect": "Allow",
+                                    "Action": "backup:CopyIntoBackupVault",
+                                    "Resource": dest_vault_arn,
+                                    "Condition": {"StringEquals": {"aws:SourceAccount": self.account_id}}
+                                }
+                                policy_details.update({
+                                    'Policy': '{"Version":"2012-10-17","Statement":[' + str(policy_statement).replace("'", '"') + ']}',
+                                    'PolicyType': model.PolicyType.RESOURCE_BASED_POLICY
+                                })
+                                policies.append(policy_details)
+        except Exception as e:
+            self.logger.warning(f"Could not check backup plans: {e}")
+        return policies

--- a/source/lambda/tests/test_policy_explorer/test_scan_backup_vault_access.py
+++ b/source/lambda/tests/test_policy_explorer/test_scan_backup_vault_access.py
@@ -74,7 +74,9 @@ def test_mock_backup_scan_policy(mocker):
 
 def mock_backup(mocker,
                 list_backup_vaults_response=None,
-                get_backup_vault_access_policy_response=None):
+                get_backup_vault_access_policy_response=None,
+                list_backup_plans_response=None,
+                get_backup_plan_response=None):
 
     # ARRANGE
     if list_backup_vaults_response is None:
@@ -82,6 +84,12 @@ def mock_backup(mocker,
 
     if get_backup_vault_access_policy_response is None:
         get_backup_vault_access_policy_response = []
+
+    if list_backup_plans_response is None:
+        list_backup_plans_response = []
+
+    if get_backup_plan_response is None:
+        get_backup_plan_response = {}
 
     def mock_list_backup_vaults(self):
         return list_backup_vaults_response
@@ -98,3 +106,67 @@ def mock_backup(mocker,
         "aws.services.backup.Backup.get_backup_vault_access_policy",
         mock_get_backup_vault_access_policy
     )
+
+    def mock_list_backup_plans(self):
+        return list_backup_plans_response
+
+    mocker.patch(
+        "aws.services.backup.Backup.list_backup_plans",
+        mock_list_backup_plans
+    )
+
+    def mock_get_backup_plan(self, backup_plan_id: str):
+        return get_backup_plan_response
+
+    mocker.patch(
+        "aws.services.backup.Backup.get_backup_plan",
+        mock_get_backup_plan
+    )
+
+
+@mock_aws
+def test_backup_plan_with_cross_account_copy_rule(mocker):
+    # ARRANGE
+    list_backup_vaults_response: list[BackupVaultListMemberTypeDef] = []
+    get_backup_vault_access_policy_response: GetBackupVaultAccessPolicyOutputTypeDef = {}
+
+    list_backup_plans_response = [
+        {
+            "BackupPlanId": "plan-123",
+            "BackupPlanArn": "arn:aws:backup:us-east-2:111111111111:backup-plan:plan-123",
+            "BackupPlanName": "DailyBackup",
+        }
+    ]
+
+    get_backup_plan_response = {
+        "BackupPlan": {
+            "BackupPlanName": "DailyBackup",
+            "Rules": [
+                {
+                    "RuleName": "DailyRule",
+                    "TargetBackupVaultName": "source_vault",
+                    "CopyActions": [
+                        {
+                            "DestinationBackupVaultArn": "arn:aws:backup:us-west-2:222222222222:backup-vault:destination_vault",
+                            "Lifecycle": {}
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+
+    mock_backup(mocker,
+                list_backup_vaults_response,
+                get_backup_vault_access_policy_response,
+                list_backup_plans_response,
+                get_backup_plan_response)
+
+    # ACT
+    response = BackupVaultAccessPolicy(event).scan()
+    logger.info(response)
+
+    # ASSERT
+    assert len(list(response)) > 0
+    found_cross_account_copy = any('222222222222' in str(item) for item in response)
+    assert found_cross_account_copy, "Should detect backup plan with cross-account copy to account 222222222222"


### PR DESCRIPTION
Customer has deployed this solution and had an issue for one account (111111111111) having AWS Backup cross-account copy feature.

On account 111111111111, AWS Backup is used to schedule Amazon RDS snapshots (within same account) and to copy them into another account 222222222222 (so x2 backup plans every day)

When migrating the account 111111111111, they noticed that AWS Backup plan to copy job in account 222222222222 failed:
```
Access denied: Copy job failed. Both source and destination account must be a member of the same organization
```

[Source](https://docs.aws.amazon.com/aws-backup/latest/devguide/create-cross-account-backup.html)

For the context, there is no other settings:
* no backup policies
* no policies attached to organization’s root account (SCP and RCP are disabled in organization service)
* no delegated admins in organization

I'll test this with customer. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the
terms of your choice.
